### PR TITLE
Fix JupyterHub version to 1.2.2 to prevent 500

### DIFF
--- a/gke-hub-example/docker/hub/Dockerfile
+++ b/gke-hub-example/docker/hub/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM jupyterhub/jupyterhub:latest
+FROM jupyterhub/jupyterhub:1.2.2
 
 # Install gcloud
 RUN apt-get update && apt-get install -y curl apt-transport-https ca-certificates gnupg \


### PR DESCRIPTION
Non-backward compatible change in JupyterLab 1.3 breaks GCP Proxy Authenticator:
- With v1.3, render_template default to asyc which breaks the first login to Dataproc Hub.
- Although we can set a sync=True parameter in the GCP Proxy Authenticator, for now pinning JupyterHub version to 1.2.2 also fix the problem.

Equivalent change in Dataproc Hub: https://github.com/GoogleCloudDataproc/jupyterhub-dataprocspawner/pull/58